### PR TITLE
Autoconfigure actors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ COLOR ?= always # Valid COLOR options: {always, auto, never}
 CARGO = cargo --color $(COLOR)
 BUILDER = ewbankkit/rust-amazonlinux:1.41.1-2018.03.0.20191219.0
 
-.PHONY: all build check clean doc release test update
+.PHONY: all build check clean doc fmt release test update
 
 all: build
 
@@ -17,6 +17,9 @@ clean:
 
 doc:
 	@$(CARGO) doc
+
+fmt:
+	@$(CARGO) fmt
 
 release:
 	@docker run --user "$(id -u)":"$(id -g)" --volume $(PWD):/volume --rm --tty $(BUILDER) cargo build --release

--- a/codec/src/lambda.rs
+++ b/codec/src/lambda.rs
@@ -34,12 +34,13 @@ pub struct Response {
 
 impl Response {
     pub fn empty() -> Response {
-        Response {
-            body: vec![],
-        }
+        Response { body: vec![] }
     }
 
-    pub fn json<T>(v: &T) -> Result<Response, Box<dyn std::error::Error>> where T: serde::ser::Serialize + ?Sized {
+    pub fn json<T>(v: &T) -> Result<Response, Box<dyn std::error::Error>>
+    where
+        T: serde::ser::Serialize + ?Sized,
+    {
         Ok(Response {
             body: serde_json::to_vec(v)?,
         })

--- a/examples/custom/manifest.yaml
+++ b/examples/custom/manifest.yaml
@@ -6,16 +6,4 @@ capabilities:
   # Layers are extracted to the /opt directory in the function execution environment.
   - /opt/libwascc_log.so
 
-config:
-  - actor: "MBIZTJVL56GKYPVDX3WW3UOUJQZFKQAHM2EQOSZ3P5B7K4WZNMAX4X2L"
-    capability: "awslambda:runtime"
-    # These environment variables are set by the Lambda machinery.
-    # https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
-    values:
-      AWS_LAMBDA_FUNCTION_NAME: "${AWS_LAMBDA_FUNCTION_NAME}"
-      AWS_LAMBDA_FUNCTION_VERSION: "${AWS_LAMBDA_FUNCTION_VERSION}"
-      AWS_LAMBDA_LOG_GROUP_NAME: "${AWS_LAMBDA_LOG_GROUP_NAME}"
-      AWS_LAMBDA_LOG_STREAM_NAME: "${AWS_LAMBDA_LOG_STREAM_NAME}"
-      AWS_LAMBDA_RUNTIME_API: "${AWS_LAMBDA_RUNTIME_API}"
-      LAMBDA_RUNTIME_DIR: "${LAMBDA_RUNTIME_DIR}"
-      LAMBDA_TASK_ROOT: "${LAMBDA_TASK_ROOT}"
+config: []

--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -36,7 +36,7 @@ use std::thread;
 
 mod lambda;
 
-const CAPABILITY_ID: &str = "awslambda:runtime";
+pub const CAPABILITY_ID: &str = "awslambda:runtime";
 
 capability_provider!(AwsLambdaRuntimeProvider, AwsLambdaRuntimeProvider::new);
 
@@ -215,7 +215,14 @@ impl AwsLambdaRuntimeClient {
                 };
                 let buf = serialize(event).unwrap();
                 let lock = self.dispatcher.read().unwrap();
-                lock.dispatch(&format!("{}!{}", &self.module_id, runtime_codec::lambda::OP_HANDLE_EVENT), &buf)
+                lock.dispatch(
+                    &format!(
+                        "{}!{}",
+                        &self.module_id,
+                        runtime_codec::lambda::OP_HANDLE_EVENT
+                    ),
+                    &buf,
+                )
             };
             // Handle response or error.
             match handler_resp {

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -27,9 +27,10 @@ use wascc_host::{host, HostManifest, NativeCapability};
 
 const MANIFEST_FILE: &str = "manifest.yaml";
 
-// Entry point.
+/// Entry point.
 fn main() -> Result<(), Box<dyn Error>> {
-    if env_logger::try_init().is_err() {
+    // No timestamp in the log format as CloudWatch already adds it.
+    if env_logger::builder().format_timestamp(None).try_init().is_err() {
         info!("Logger already intialized");
     }
 


### PR DESCRIPTION
Autoconfigure any loaded actors that have the `awslambda:runtime` capability to avoid complex and error-prone configuration via `manifest.yaml`.