### PR TITLE
Use wascc-host v0.9.0

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Kit Ewbank <Kit_Ewbank@hotmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ log = "0.4.8"
 anyhow = "1.0.31"
 wascc-codec = "0.7.1"
 provider = { path = "../provider" }
-wascc-host = { version = "0.8.0", features = ["manifest"] }
+wascc-host = { version = "0.9.0", features = ["manifest"] }
 wascc-logging = { version = "0.7.0", features = ["static_plugin"] }
 
 [[bin]]


### PR DESCRIPTION
Closes https://github.com/wascc/aws-lambda-wascc-runtime/issues/46.