### PR TITLE
wascc-host v0.10.1

### DIFF
--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "codec"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Kit Ewbank <Kit_Ewbank@hotmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-serde = "1.0.111"
-serde_derive = "1.0.111"
-serde_json = "1.0.53"
-serde_bytes = "0.11.4"
+serde = "1.0.114"
+serde_derive = "1.0.114"
+serde_json = "1.0.56"
+serde_bytes = "0.11.5"

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "provider"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Kit Ewbank <Kit_Ewbank@hotmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-log = "0.4.8"
+log = "0.4.11"
 anyhow = "1.0.31"
-wascc-codec = "0.7.1"
+wascc-codec = "0.7.2"
 reqwest = { version = "0.10.6", features = ["blocking", "json"] }
-serde = "1.0.111"
-serde_json = "1.0.53"
+serde = "1.0.114"
+serde_json = "1.0.56"
 codec = { path = "../codec" }
 aws_lambda_events = "0.3.0"
-base64 = "0.12.1"
+base64 = "0.12.3"
 url = "2.1.1"
-thiserror = "1.0.19"
+thiserror = "1.0.20"
 
 [dev-dependencies]
 httptest = "0.13.1"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Kit Ewbank <Kit_Ewbank@hotmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,11 +8,11 @@ readme = "README.md"
 
 [dependencies]
 env_logger = "0.7.1"
-log = "0.4.8"
+log = "0.4.11"
 anyhow = "1.0.31"
-wascc-codec = "0.7.1"
+wascc-codec = "0.7.2"
 provider = { path = "../provider" }
-wascc-host = { version = "0.9.0", features = ["manifest"] }
+wascc-host = { version = "0.10.1", features = ["manifest"] }
 wascc-logging = { version = "0.7.0", features = ["static_plugin"] }
 
 [[bin]]


### PR DESCRIPTION
Closes https://github.com/wascc/aws-lambda-wascc-runtime/issues/49.